### PR TITLE
just a test branch for getting ios working with fork of substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,18 @@ members = ["native/*"]
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+[patch.crates-io]
+frame-metadata = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+frame-support = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+frame-system = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+pallet-balances = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+pallet-indices = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-core = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-io = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-keyring = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-rpc = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-runtime = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-std = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-transaction-pool = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }
+sp-version = { git = "https://github.com/4meta5/substrate/", branch = "ios-ignore-sysinfo" }


### PR DESCRIPTION
## fork of substrate info

Here is the fork, right on top of v2.0.0-rc4 tag so that there aren't version problems involving master vs substrate-subxt: https://github.com/4meta5/substrate/tree/ios-ignore-sysinfo

**what did I change?** see the last three commits on that branch, I ignored "ios" for sysinfo and netstat in the Cargo.toml and the metrics.rs file.

## this branch and the current error

I'm referencing the fork in the `patches.crates-io` of the Cargo.toml and it is still returning this error when I run `cargo make ios` in the root

```
error[E0425]: cannot find function `iterate_sockets_info` in this scope
  --> /Users/4meta5/.cargo/registry/src/github.com-1ecc6299db9ec823/netstat2-0.8.1/src/integrations/shared_api.rs:11:5
   |
7  | / pub fn get_sockets_info(
8  | |     af_flags: AddressFamilyFlags,
9  | |     proto_flags: ProtocolFlags,
10 | | ) -> Result<Vec<SocketInfo>, Error> {
11 | |     iterate_sockets_info(af_flags, proto_flags)?.collect()
   | |     ^^^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `get_sockets_info`
12 | | }
   | |_- similarly named function `get_sockets_info` defined here

error[E0425]: cannot find value `CLOCK_BOOTTIME` in crate `libc`
    --> /Users/4meta5/.cargo/registry/src/github.com-1ecc6299db9ec823/sysinfo-0.13.4/src/linux/system.rs:121:43
     |
121  |     if unsafe { libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut up) } == 0 {
     |                                           ^^^^^^^^^^^^^^ help: a constant with a similar name exists: `CLOCK_REALTIME`
     | 
    ::: /Users/4meta5/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.71/src/unix/bsd/apple/mod.rs:1346:1
     |
1346 | pub const CLOCK_REALTIME: ::clockid_t = 0;
     | ------------------------------------------ similarly named constant `CLOCK_REALTIME` defined here

   Compiling prost-build v0.6.1
error: aborting due to previous error

For more information about this error, try `rustc --explain E0425`.
error: could not compile `netstat2`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error[E0308]: mismatched types
  --> /Users/4meta5/.cargo/registry/src/github.com-1ecc6299db9ec823/sysinfo-0.13.4/src/linux/users.rs:42:37
   |
42 | ...                   group_id,
   |                       ^^^^^^^^ expected `i32`, found `u32`
   |
help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
   |
42 |                                     group_id.try_into().unwrap(),
   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0308, E0425.
For more information about an error, try `rustc --explain E0308`.
error: build failed
[ERROR cargo_lipo] Failed to build "identity-client" for "aarch64-apple-ios": Executing "/Users/4meta5/.rustup/toolchains/nightly-x86_64-apple-darwin/bin/cargo" "--color" "auto" "build" "-p" "identity-client" "--target" "aarch64-apple-ios" "--lib" finished with error status: exit code: 101
[cargo-make][1] ERROR - Error while executing command, exit code: 1
[cargo-make][1] WARN - Build Failed.
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```